### PR TITLE
Allow babel transformation to parallelized

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function (defaults) {
   const app = new EmberAddon(defaults, {
-    // Add options here
+    'ember-cli-babel': {
+      throwUnlessParallelizable: true,
+    },
   });
 
   /*

--- a/index.js
+++ b/index.js
@@ -8,16 +8,10 @@ module.exports = {
   },
 
   _buildPlugin() {
-    const ThisFallbackPlugin = require('./lib/this-fallback-plugin');
-
-    // HACK: Seems strange that this is necessary, but without it we get:
-    // broccoli-babel-transpiler is opting out of caching due to a plugin that does not provide a caching strategy
-    ThisFallbackPlugin.baseDir = () => __dirname;
-
     return {
       name: 'ember-this-fallback',
       baseDir: () => __dirname,
-      plugin: ThisFallbackPlugin,
+      plugin: require.resolve('./lib/this-fallback-plugin'),
     };
   },
 };


### PR DESCRIPTION
When the `ember-cli-babel.throwUnlessParallelizable` flag was enabled, this addon would cause an error to be raised like

```
[broccoli-persistent-filter:Babel > [Babel: ember-this-fallback]: Babel: ember-this-fallback] was configured to `throwUnlessParallelizable` and was unable to parallelize a plugin.
```

This commit updates the plugin definition to be compatible with parallel transformations, and adds the `throwUnlessParallelizable` flag to the dummy app. This change also seems to resolve the 'opting out of caching' error which previously required a `baseDir` hack.

More info on parallelization at https://github.com/babel/ember-cli-babel#parallel-builds and https://github.com/babel/broccoli-babel-transpiler#parallel-transpilation