### PR TITLE
Failing example with angle-bracket syntax

### DIFF
--- a/tests/integration/plugin/block-statement-test.ts
+++ b/tests/integration/plugin/block-statement-test.ts
@@ -124,4 +124,15 @@ module('Integration | Plugin | BlockStatement', function (hooks) {
       });
     });
   });
+
+  // TODO - this test should not be here. Just using as a demonstration
+  module("example failure", function(){
+    test("example", async function(assert){
+      this.set("someVar", "a-string")
+      await render(hbs`
+        <GlobalComponent @arg={{someVar}} />
+      `)
+      assert.dom().hasText('global-component-contents a-string')
+    })
+  })
 });


### PR DESCRIPTION
This template fails to compile

```
ember-this-fallback/dummy/tests/integration/plugin/block-statement-test.ts: Cannot read properties of undefined (reading 'expr')
```

(I just stuck the file example in a random test file - it should probably be moved elsewhere)