### PR TITLE
Fix support for nested components in mustache statement

### DIFF
--- a/lib/helpers/string.ts
+++ b/lib/helpers/string.ts
@@ -19,5 +19,7 @@ export function squish(str: string): string {
 }
 
 export function classify(str: string): string {
-  return upperFirst(camelCase(str));
+  const parts = str.split('/');
+  const classifiedParts = parts.map((p) => upperFirst(camelCase(p)));
+  return classifiedParts.join('::');
 }

--- a/tests/dummy/app/components/somedir/nested-global-component.hbs
+++ b/tests/dummy/app/components/somedir/nested-global-component.hbs
@@ -1,0 +1,3 @@
+<div ...attributes data-test-global-component>
+  nested-global-component-contents
+</div>

--- a/tests/dummy/app/components/somedir/nested-global-component.ts
+++ b/tests/dummy/app/components/somedir/nested-global-component.ts
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+interface GlobalComponentSignature<Arg = string | undefined> {
+  Element: HTMLDivElement;
+}
+
+// eslint-disable-next-line ember/no-empty-glimmer-component-classes
+export default class NestedGlobalComponent extends Component<GlobalComponentSignature> {}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'somedir/nested-global-component': typeof NestedGlobalComponent;
+  }
+}

--- a/tests/integration/plugin/mustache-statement-test.ts
+++ b/tests/integration/plugin/mustache-statement-test.ts
@@ -28,6 +28,11 @@ module('Integration | Plugin | MustacheStatement', function (hooks) {
             assert.dom().hasText('global-component-contents');
           });
 
+          test('handles a nested invocable component', async function (assert) {
+            await render(hbs`{{somedir/nested-global-component}}`);
+            assert.dom().hasText('nested-global-component-contents');
+          });
+
           test('does nothing to an invocable modifier', async function (assert) {
             await render(hbs`<div {{global-modifier}} />`);
             assert.dom().hasText('global-modifier-result');


### PR DESCRIPTION
The implementation of `classify()` was converting component invocations like `{{dir/component-name}}` to `<DirComponentName />`. This commit fixes the classify function to replace `/` with `::`.